### PR TITLE
Add /events/addevent and /events/:id endpoints

### DIFF
--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -1,6 +1,33 @@
 const express = require('express');
 const router = express.Router();
 
+// Add game event to db
+router.post('/addevent', (req, res, next) => {
+  const { event_type, event_zone, username, game_id, game_time } = req.body;
+
+  req.db
+    .from('game_plays')
+    .insert({
+      game_id,
+      game_time,
+      event_type,
+      event_zone,
+      username,
+    })
+    .then(([id]) => {
+      res.json({
+        status: 200,
+        message: `Successfully created entry; Type: ${event_type}, Zone: ${event_zone}, Event id: ${id}`,
+      });
+    })
+    .catch(error => {
+      res.status(500).json({
+        error: true,
+        message: `Unable to POST ${error.message}.`,
+      });
+    });
+});
+
 // DB test - Insert A
 router.post('/insertA', (req, res, next) => {
   req.db
@@ -20,31 +47,15 @@ router.post('/insertA', (req, res, next) => {
     });
 });
 
-// DB test - Insert B
-router.post('/insertB', (req, res, next) => {
-  req.db
-    .from('concept_events')
-    .insert({ event: 'B' })
-    .then(() => {
-      res.json({
-        status: 200,
-        message: 'Success.',
-      });
-    })
-    .catch(error => {
-      res.status(500).json({
-        error: true,
-        message: 'Unable to post B to DB.',
-      });
-    });
-});
+// Return all events for a given game_id
+router.get('/:id', (req, res, next) => {
+  const game_id = req.params.id;
 
-// DB test - show all
-router.get('/viewData', (req, res, next) => {
   req.db
-    .from('concept_events')
+    .from('game_plays')
     .select('*')
-    .orderBy('id', 'asc')
+    .where('game_id', game_id)
+    .orderBy('game_id', 'asc')
     .then(data => {
       res.json({
         status: 200,


### PR DESCRIPTION
This PR adds additional API endpoints for working with game events in the MySQL DB.

- Added POST /events/addevent route to insert a new game event using a request body (game_id, game_time, event_type, event_zone, username)
- Added GET /events/:id route to retrieve all events for a given game_id
- Removed legacy /insertB route from initial conceptual phase
- Tested and confirmed endpoints are able to write to the database and retrieve all game events as required.

<img width="984" height="515" alt="image" src="https://github.com/user-attachments/assets/a0f3f7d8-8aea-4130-9164-dd4c3fc4b61c" />

<img width="918" height="856" alt="image" src="https://github.com/user-attachments/assets/3bdc3725-ae16-4ee7-b472-7af242fe83d2" />
